### PR TITLE
fix: correct occured to occurred typo in sysinfo.lua

### DIFF
--- a/service/http/sysinfo.lua
+++ b/service/http/sysinfo.lua
@@ -21,4 +21,4 @@ if ngx.config.subsystem ~= 'http' then
     error("only works in http subsystem")
 end
 
-ngx.log(ngx.ERR, "some error occured")
+ngx.log(ngx.ERR, "some error occurred")


### PR DESCRIPTION
Fix a single character typo in an error log message.

- File: service/http/sysinfo.lua:24
- Change: `occured` → `occurred`

1 file, 1 line — all in code.